### PR TITLE
Escape several strings, especially title

### DIFF
--- a/404.md
+++ b/404.md
@@ -10,6 +10,6 @@ is_wiki_page: false
     if (!filename.endsWith(".md"))
         filename+=".md";
 
-    var url = '{{ site.github.repository_url }}/new/{{site.git_branch}}?filename={{ site.wiki_folder | default: 'wiki' }}/'+filename;
+    var url = '{{ site.github.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.wiki_folder | default: 'wiki' }}/'+filename;
     window.location=url;
 </script>

--- a/_includes/git-wiki/components/action_btn/page_actions.html
+++ b/_includes/git-wiki/components/action_btn/page_actions.html
@@ -5,28 +5,28 @@
     <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/wiki/{{url | remove: '.html' | append: ''}}/_history">History</a></span>
     <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/wiki/{{url | remove: '.html' | append: '.md'}}/">Source</a></span>
     {% else %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch}}?filename={{ site.wiki_folder | default: 'wiki' }}/">Add
+    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch | escape}}?filename={{ site.wiki_folder | default: 'wiki' }}/">Add
             new</a></span>
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/edit/{{site.git_branch}}/{{page.path}}">Edit</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/edit/{{site.git_branch | escape}}/{{page.path | escape}}">Edit</a></span>
     {% if site.service == "gitlab" %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch}}/{{page.path}}">Delete</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch | escape}}/{{page.path | escape}}">Delete</a></span>
     {% else %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/delete/{{site.git_branch}}/{{page.path}}">Delete</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/delete/{{site.git_branch | escape}}/{{page.path | escape}}">Delete</a></span>
     {% endif %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/commits/{{site.git_branch}}/{{page.path}}">History</a></span>
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch}}/{{page.path}}">Source</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/commits/{{site.git_branch | escape}}/{{page.path | escape}}">History</a></span>
+    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/blob/{{site.git_branch | escape}}/{{page.path | escape}}">Source</a></span>
     {% if site.blog_feature %}
-    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch}}?filename=_posts/">Add
+    <span class="tools-element"><a target="_blank" href="{{ site.github.repository_url }}/new/{{site.git_branch | escape}}?filename=_posts/">Add
             new post</a></span>
     {% endif %}
     {% if site.use_prose_io and site.service == "github" %}
     <br>
     Prose.io:
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch}}/{{ site.wiki_folder | default: 'wiki' }}">Add
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch | escape}}/{{ site.wiki_folder | default: 'wiki' }}">Add
             new</a></span>
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/edit/{{site.git_branch}}/{{page.path}}">Edit</a></span>
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/edit/{{site.git_branch | escape}}/{{page.path | escape}}">Edit</a></span>
     {% if site.blog_feature %}
-    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch}}/_posts/">Add
+    <span class="tools-element"><a target="_blank" href="http://prose.io/#{{site.github.repository_nwo}}/new/{{site.git_branch | escape}}/_posts/">Add
             new post</a></span>
     {% endif %}
     {% endif %}

--- a/_includes/git-wiki/components/lists/page-list.html
+++ b/_includes/git-wiki/components/lists/page-list.html
@@ -15,7 +15,7 @@
         {% if page.is_wiki_page != false and page.sitemap != false %}
         <li class="page-list-item">
             {% assign title = page.title | default: page.name %}
-            <a href="{{ page.url | relative_url }}">{{title}}</a>
+            <a href="{{ page.url | relative_url }}">{{title | escape}}</a>
         </li>
         {% assign numPages = numPages | plus: 1 %}
         {% endif %}

--- a/_includes/git-wiki/components/lists/post-list.html
+++ b/_includes/git-wiki/components/lists/post-list.html
@@ -15,7 +15,7 @@
 
         {% if post.layout != "null" and post.sitemap != false and post.title %}
         <li class="post-list-item">
-            <a href="{{ post.url | relative_url }}">{{ post.title}}</a>
+            <a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
         </li>
         {% assign numPages = numPages | plus: 1 %}
         {% endif %}

--- a/_includes/git-wiki/components/logo/logo.html
+++ b/_includes/git-wiki/components/logo/logo.html
@@ -1,6 +1,6 @@
 <div class="git-wiki-main-logo">
     <a href="{{ '/' | relative_url }}"><img src="{{ site.logo_url }}">
-        <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        <h1>{{ site.title | default: site.github.repository_name | escape }}</h1>
     </a>
     <p>{{ site.description | default: site.github.project_tagline }}</p>
 </div>

--- a/_includes/git-wiki/sections/header/header.html
+++ b/_includes/git-wiki/sections/header/header.html
@@ -2,7 +2,7 @@
   <button class="w3-button w3-teal" onclick="sidebar_toggle()">&#9776;</button>
   <a href="{{ '/' | relative_url }}">
     <img src="{{ site.logo_url }}" width="20px">
-    {{ site.title }}
+    {{ site.title | escape }}
   </a>
 </div>
 <header class="w3-sidebar w3-bar-block w3-collapse" id="git-wiki-sidebar">


### PR DESCRIPTION
This PR fixes #70

## Description

This PR escapes `title`, `path` and `git_branch` when it is located in HTML tags or quotations.
This PR does *not* escape some strings such as [`site.github.zip_url`](https://github.com/Drassil/git-wiki/blob/8c447f9f53c9630d525b1d1cdaf80038c875d944/_includes/git-wiki/components/action_btn/downloads.html#L2); if they're should be escaped too, feel free to commit more =)

## Related Issue

#70

## Motivation and Context

See #70 and/or <https://github.com/nekketsuuu/git-wiki-70-noescape>.

## How Has This Been Tested?

I tested this on another repository <https://github.com/nekketsuuu/git-wiki-70-escaped>.
This repository is one commit ahead to the above one; some strings are escaped as this PR does.

## Screenshots (if appropriate):

![all special characters displayed correctly](https://user-images.githubusercontent.com/4374702/71713272-5ebc1c80-2e4c-11ea-8c7e-4aefbe448130.png)
