### PR TITLE
Fix logo on mobile

### DIFF
--- a/_includes/git-wiki/sections/header/header.html
+++ b/_includes/git-wiki/sections/header/header.html
@@ -1,7 +1,9 @@
 <div class=" w3-xlarge w3-hide-large" id="git-wiki-mobile-header">
   <button class="w3-button w3-teal" onclick="sidebar_toggle()">&#9776;</button>
   <a href="{{ '/' | relative_url }}">
+    {% if site.logo_url %}
     <img src="{{ site.logo_url }}" width="20px">
+    {% endif %}
     {{ site.title }}
   </a>
 </div>


### PR DESCRIPTION
Don't show a logo on header for mobile if `logo_url` is not set.

## Description

Currently, an logo img tag is generated even if `logo_url` is not set.

```html
    <div class=" w3-xlarge w3-hide-large" id="git-wiki-mobile-header">
  <button class="w3-button w3-teal" onclick="sidebar_toggle()">&#9776;</button>
  <a href="/">
    <img src="" width="20px">
    git-wiki
  </a>
</div>
```

By this pull request, this unnecessary img tag is not generated.

```html
    <div class=" w3-xlarge w3-hide-large" id="git-wiki-mobile-header">
  <button class="w3-button w3-teal" onclick="sidebar_toggle()">&#9776;</button>
  <a href="/">
    
    git-wiki
  </a>
</div>
```

## Related Issue

#74

## How Has This Been Tested?

I tested by a local build.