### PR TITLE
Fix repository name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# git-wiki-demo
+# git-wiki
 
 Demo and documentation for git-wiki-theme: https://github.com/Drassil/git-wiki-theme


### PR DESCRIPTION
This repository is Drassil/git-wiki, not Drassil/git-wiki-demo.